### PR TITLE
Update angular peer dependencies to v4

### DIFF
--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/scttcper/ngx-toastr",
   "peerDependencies": {
-    "@angular/core": "^2.4.0",
-    "@angular/common": "^2.4.0",
+    "@angular/core": "^4.0.0",
+    "@angular/common": "^4.0.0",
     "rxjs": "^5.0.0"
   }
 }


### PR DESCRIPTION
Solves peer dependency warning when trying to use `ngx-toastr@5.0.3` with `angular@4.0.0`

> npm WARN ngx-toastr@5.0.3 requires a peer of @angular/common@^2.4.0 but none was installed

Don't forget to release a patch!