### PR TITLE
Fix toast-container overlay UI blocking

### DIFF
--- a/src/lib/toastr.css
+++ b/src/lib/toastr.css
@@ -80,6 +80,7 @@ button.toast-close-button {
   left: 12px;
 }
 #toast-container {
+  pointer-events: none;
   position: fixed;
   z-index: 999999;
   /*overrides*/
@@ -139,6 +140,7 @@ button.toast-close-button {
 }
 .toast {
   background-color: #030303;
+  pointer-events: auto;
 }
 .toast-success {
   background-color: #51A351;


### PR DESCRIPTION
The issue this pull request resolves is most visible when using the 'toast-top-center' positionClass. The toast-container overlay takes up the width of the screen and blocks any interaction with UI elements beneath it. See the following Plunker for an example:

http://plnkr.co/edit/EMoEzrtKvyOIfC2yoOct

Adding pointer-events style properties for _#toast-container_ and _.toast_ resolves the issues.