### PR TITLE
refactor: remove un-used, transitive NgZone dependency

### DIFF
--- a/src/lib/overlay/overlay-ref.ts
+++ b/src/lib/overlay/overlay-ref.ts
@@ -7,8 +7,7 @@ import {BasePortalHost, ComponentPortal} from '../portal/portal';
  */
 export class OverlayRef {
   constructor(
-      private _portalHost: BasePortalHost,
-      private _pane: HTMLElement) { }
+      private _portalHost: BasePortalHost) { }
 
   attach(portal: ComponentPortal<any>, newestOnTop: boolean): ComponentRef<any> {
     return this._portalHost.attach(portal, newestOnTop);

--- a/src/lib/overlay/overlay-ref.ts
+++ b/src/lib/overlay/overlay-ref.ts
@@ -8,8 +8,7 @@ import {BasePortalHost, ComponentPortal} from '../portal/portal';
 export class OverlayRef {
   constructor(
       private _portalHost: BasePortalHost,
-      private _pane: HTMLElement,
-      private _ngZone: NgZone) { }
+      private _pane: HTMLElement) { }
 
   attach(portal: ComponentPortal<any>, newestOnTop: boolean): ComponentRef<any> {
     return this._portalHost.attach(portal, newestOnTop);

--- a/src/lib/overlay/overlay.ts
+++ b/src/lib/overlay/overlay.ts
@@ -19,8 +19,7 @@ import { ToastContainerDirective } from '../toastr/toast-directive';
     private _paneElements: {string?: HTMLElement} = {};
     constructor(private _overlayContainer: OverlayContainer,
                 private _componentFactoryResolver: ComponentFactoryResolver,
-                private _appRef: ApplicationRef,
-                private _ngZone: NgZone) {}
+                private _appRef: ApplicationRef) {}
   /**
    * Creates an overlay.
    * @returns A reference to the created overlay.
@@ -68,7 +67,7 @@ import { ToastContainerDirective } from '../toastr/toast-directive';
    * @param pane DOM element for the overlay
    */
   private _createOverlayRef(pane: HTMLElement): OverlayRef {
-    return new OverlayRef(this._createPortalHost(pane), pane, this._ngZone);
+    return new OverlayRef(this._createPortalHost(pane), pane);
   }
 }
 

--- a/src/lib/overlay/overlay.ts
+++ b/src/lib/overlay/overlay.ts
@@ -67,7 +67,7 @@ import { ToastContainerDirective } from '../toastr/toast-directive';
    * @param pane DOM element for the overlay
    */
   private _createOverlayRef(pane: HTMLElement): OverlayRef {
-    return new OverlayRef(this._createPortalHost(pane), pane);
+    return new OverlayRef(this._createPortalHost(pane));
   }
 }
 


### PR DESCRIPTION
this is wird ... the guys at [material2 use `_ngZone` just for bypassing async tests](https://github.com/angular/material2/blob/master/src/lib/core/overlay/overlay-ref.ts#L221-L226). since ngx-toastr has no backdrop, `_ngZone` seems to be an unused dependency.