### PR TITLE
Fix iconClasses override when using forRoot()

### DIFF
--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -89,10 +89,10 @@ export class ToastrConfig extends ToastConfig {
     this.newestOnTop = use(config.newestOnTop, this.newestOnTop);
     this.preventDuplicates = use(config.preventDuplicates, this.preventDuplicates);
     if (config.iconClasses) {
-      this.iconClasses.error = this.iconClasses.error || config.iconClasses.error;
-      this.iconClasses.info = this.iconClasses.info || config.iconClasses.info;
-      this.iconClasses.success = this.iconClasses.success || config.iconClasses.success;
-      this.iconClasses.warning = this.iconClasses.warning || config.iconClasses.warning;
+      this.iconClasses.error = config.iconClasses.error || this.iconClasses.error;
+      this.iconClasses.info = config.iconClasses.info || this.iconClasses.info;
+      this.iconClasses.success = config.iconClasses.success || this.iconClasses.success;
+      this.iconClasses.warning = config.iconClasses.warning || this.iconClasses.warning;
     }
   }
 }


### PR DESCRIPTION
When setting iconClasses globally using forRoot(), iconClasses wasn't getting set properly.

This fixes #131 