### PR TITLE
Automatically sanitize HTML

### DIFF
--- a/src/lib/toastr/toast-component.ts
+++ b/src/lib/toastr/toast-component.ts
@@ -9,6 +9,7 @@ import {
   HostBinding,
   HostListener,
   ApplicationRef,
+  SecurityContext,
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Subscription } from 'rxjs/Subscription';
@@ -81,7 +82,7 @@ export class Toast implements OnDestroy {
     this.toastId = data.toastId;
     this.message = data.message;
     if (this.message && this.options.enableHtml) {
-      this.message = sanitizer.bypassSecurityTrustHtml(data.message);
+      this.message = sanitizer.sanitize(SecurityContext.HTML, data.message);
     }
     this.title = data.title;
     this.onTap = data.onTap;


### PR DESCRIPTION
Sanitizing the html removes any potentially dangerous content, while still allowing safe html tags.  This is safer than just running `bypassSecurtiyTrustHtml`