### PR TITLE
Clean up config overrides

### DIFF
--- a/src/lib/toastr/default-config.ts
+++ b/src/lib/toastr/default-config.ts
@@ -1,0 +1,31 @@
+import { GlobalConfig } from './toastr-config';
+import { Toast } from "./toast-component";
+
+export class DefaultGlobalConfig implements GlobalConfig {
+    //Global
+    maxOpened = 0;
+    autoDismiss = false;
+    newestOnTop = true;
+    preventDuplicates = false;
+    iconClasses = {
+      error: 'toast-error',
+      info: 'toast-info',
+      success: 'toast-success',
+      warning: 'toast-warning',
+    };
+
+    // Individual
+    toastComponent = Toast;
+    closeButton = false;
+    timeOut = 5000;
+    extendedTimeOut = 1000;
+    enableHtml = false;
+    progressBar = false;
+    toastClass = 'toast';
+    positionClass = 'toast-top-right';
+    titleClass = 'toast-title';
+    messageClass = 'toast-message';
+    tapToDismiss = true;
+    onActivateTick = false;
+  }
+  

--- a/src/lib/toastr/default-config.ts
+++ b/src/lib/toastr/default-config.ts
@@ -1,8 +1,8 @@
 import { GlobalConfig } from './toastr-config';
-import { Toast } from "./toast-component";
+import { Toast } from './toast-component';
 
 export class DefaultGlobalConfig implements GlobalConfig {
-    //Global
+    // Global
     maxOpened = 0;
     autoDismiss = false;
     newestOnTop = true;
@@ -28,4 +28,3 @@ export class DefaultGlobalConfig implements GlobalConfig {
     tapToDismiss = true;
     onActivateTick = false;
   }
-  

--- a/src/lib/toastr/toastr-service.ts
+++ b/src/lib/toastr/toastr-service.ts
@@ -119,21 +119,21 @@ export class ToastrService {
     function use<T>(source: T, defaultValue: T): T {
       return override && source !== undefined ? source : defaultValue;
     }
-    
+
     const current: GlobalConfig = { ...this.toastrConfig };
-    
-    for (let property in current) {
+
+    for (const property of Object.keys(current)) {
       override[property] = use(override[property], current[property]);
     }
 
-    let asGlobalConfig = override as GlobalConfig;
+    const asGlobalConfig = override as GlobalConfig;
     if (asGlobalConfig.iconClasses) {
       const currentIconClasses = <ToastrIconClasses>current.iconClasses;
-      for (let property in currentIconClasses) {
+      for (const property of Object.keys(currentIconClasses)) {
         asGlobalConfig.iconClasses[property] = use(asGlobalConfig.iconClasses[property], currentIconClasses[property]);
       }
     }
-    
+
     return override;
   }
 

--- a/src/lib/toastr/toastr-service.ts
+++ b/src/lib/toastr/toastr-service.ts
@@ -1,15 +1,14 @@
-import { Injectable, Injector, ComponentRef, Inject, SecurityContext } from '@angular/core';
-import { SafeHtml } from '@angular/platform-browser';
+import { ComponentRef, Inject, Injectable, Injector, SecurityContext } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
 
 import { Overlay } from '../overlay/overlay';
 import { ComponentPortal } from '../portal/portal';
-import { GlobalConfig, IndividualConfig, ToastPackage } from './toastr-config';
-import { ToastInjector, ToastRef } from './toast-injector';
+import { DefaultGlobalConfig } from './default-config';
 import { ToastContainerDirective } from './toast-directive';
+import { ToastRef, ToastInjector } from './toast-injector';
 import { TOAST_CONFIG } from './toast-token';
-import { Toast } from './toast-component';
-import { DomSanitizer } from '@angular/platform-browser';
+import { GlobalConfig, IndividualConfig, ToastrIconClasses, ToastPackage } from './toastr-config';
 
 export interface ActiveToast {
   toastId?: number;
@@ -24,6 +23,7 @@ export interface ActiveToast {
 
 @Injectable()
 export class ToastrService {
+  toastrConfig: GlobalConfig = new DefaultGlobalConfig();
   private index = 0;
   private previousToastMessage?: string;
   currentlyActive = 0;
@@ -31,41 +31,12 @@ export class ToastrService {
   overlayContainer: ToastContainerDirective;
 
   constructor(
-    @Inject(TOAST_CONFIG) public toastrConfig: GlobalConfig,
+    @Inject(TOAST_CONFIG) toastrConfig: GlobalConfig,
     private overlay: Overlay,
     private _injector: Injector,
     private sanitizer: DomSanitizer,
   ) {
-    function use<T>(source: T, defaultValue: T): T {
-      return toastrConfig && source !== undefined ? source : defaultValue;
-    }
     this.toastrConfig = this.applyConfig(toastrConfig);
-    // Global
-    this.toastrConfig.maxOpened = use(this.toastrConfig.maxOpened, 0);
-    this.toastrConfig.autoDismiss = use(this.toastrConfig.autoDismiss, false);
-    this.toastrConfig.newestOnTop = use(this.toastrConfig.newestOnTop, true);
-    this.toastrConfig.preventDuplicates = use(this.toastrConfig.preventDuplicates, false);
-    if (!this.toastrConfig.iconClasses) {
-      this.toastrConfig.iconClasses = {};
-    }
-    this.toastrConfig.iconClasses.error = this.toastrConfig.iconClasses.error || 'toast-error';
-    this.toastrConfig.iconClasses.info = this.toastrConfig.iconClasses.info || 'toast-info';
-    this.toastrConfig.iconClasses.success = this.toastrConfig.iconClasses.success || 'toast-success';
-    this.toastrConfig.iconClasses.warning = this.toastrConfig.iconClasses.warning || 'toast-warning';
-
-    // Individual
-    this.toastrConfig.timeOut = use(this.toastrConfig.timeOut, 5000);
-    this.toastrConfig.closeButton = use(this.toastrConfig.closeButton, false);
-    this.toastrConfig.extendedTimeOut = use(this.toastrConfig.extendedTimeOut, 1000);
-    this.toastrConfig.progressBar = use(this.toastrConfig.progressBar, false);
-    this.toastrConfig.enableHtml = use(this.toastrConfig.enableHtml, false);
-    this.toastrConfig.toastClass = use(this.toastrConfig.toastClass, 'toast');
-    this.toastrConfig.positionClass = use(this.toastrConfig.positionClass, 'toast-top-right');
-    this.toastrConfig.titleClass = use(this.toastrConfig.titleClass, 'toast-title');
-    this.toastrConfig.messageClass = use(this.toastrConfig.messageClass, 'toast-message');
-    this.toastrConfig.tapToDismiss = use(this.toastrConfig.tapToDismiss, true);
-    this.toastrConfig.toastComponent = use(this.toastrConfig.toastComponent, Toast);
-    this.toastrConfig.onActivateTick = use(this.toastrConfig.onActivateTick, false);
   }
   /** show toast */
   show(message?: string, title?: string, override?: IndividualConfig, type = '') {
@@ -144,24 +115,26 @@ export class ToastrService {
   }
 
   /** create a clone of global config and apply individual settings */
-  private applyConfig(override: IndividualConfig = {}) {
+  private applyConfig(override: GlobalConfig | IndividualConfig = {}): GlobalConfig {
     function use<T>(source: T, defaultValue: T): T {
       return override && source !== undefined ? source : defaultValue;
     }
+    
     const current: GlobalConfig = { ...this.toastrConfig };
-    current.closeButton = use(override.closeButton, current.closeButton);
-    current.extendedTimeOut = use(override.extendedTimeOut, current.extendedTimeOut);
-    current.progressBar = use(override.progressBar, current.progressBar);
-    current.timeOut = use(override.timeOut, current.timeOut);
-    current.enableHtml = use(override.enableHtml, current.enableHtml);
-    current.toastClass = use(override.toastClass, current.toastClass);
-    current.positionClass = use(override.positionClass, current.positionClass);
-    current.titleClass = use(override.titleClass, current.titleClass);
-    current.messageClass = use(override.messageClass, current.messageClass);
-    current.tapToDismiss = use(override.tapToDismiss, current.tapToDismiss);
-    current.toastComponent = use(override.toastComponent, current.toastComponent);
-    current.onActivateTick = use(override.onActivateTick, current.onActivateTick);
-    return current;
+    
+    for (let property in current) {
+      override[property] = use(override[property], current[property]);
+    }
+
+    let asGlobalConfig = override as GlobalConfig;
+    if (asGlobalConfig.iconClasses) {
+      const currentIconClasses = <ToastrIconClasses>current.iconClasses;
+      for (let property in currentIconClasses) {
+        asGlobalConfig.iconClasses[property] = use(asGlobalConfig.iconClasses[property], currentIconClasses[property]);
+      }
+    }
+    
+    return override;
   }
 
   /**


### PR DESCRIPTION
Overriding the global and individual configs was repetitive and a bit messy. This should greatly clean it up and make it more readable. Now both the global and individual configs use the same method to override the config.