### PR TITLE
switch to changedetectorref 

### DIFF
--- a/src/app/notyf.toast.ts
+++ b/src/app/notyf.toast.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-access-missing-member */
-import { Component, ApplicationRef } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   trigger,
   state,
@@ -75,9 +75,8 @@ export class NotyfToast extends Toast {
   // constructor is only necessary when not using AoT
   constructor(
     protected toastrService: ToastrService,
-    public toastPackage: ToastPackage,
-    protected appRef: ApplicationRef,
+    public toastPackage: ToastPackage
   ) {
-    super(toastrService, toastPackage, appRef);
+    super(toastrService, toastPackage);
   }
 }

--- a/src/app/notyf.toast.ts
+++ b/src/app/notyf.toast.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-access-missing-member */
-import { Component, ApplicationRef } from '@angular/core';
+import { Component, ChangeDetectorRef } from '@angular/core';
 import {
   trigger,
   state,
@@ -76,8 +76,8 @@ export class NotyfToast extends Toast {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected appRef: ApplicationRef,
+    protected changeDetectorRef: ChangeDetectorRef,
   ) {
-    super(toastrService, toastPackage, appRef);
+    super(toastrService, toastPackage, changeDetectorRef);
   }
 }

--- a/src/app/notyf.toast.ts
+++ b/src/app/notyf.toast.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-access-missing-member */
-import { Component, ChangeDetectorRef } from '@angular/core';
+import { Component, ApplicationRef } from '@angular/core';
 import {
   trigger,
   state,
@@ -76,8 +76,8 @@ export class NotyfToast extends Toast {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected changeDetectorRef: ChangeDetectorRef,
+    protected appRef: ApplicationRef,
   ) {
-    super(toastrService, toastPackage, changeDetectorRef);
+    super(toastrService, toastPackage, appRef);
   }
 }

--- a/src/app/pink.toast.ts
+++ b/src/app/pink.toast.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-access-missing-member */
-import { Component, ChangeDetectorRef } from '@angular/core';
+import { Component, ApplicationRef } from '@angular/core';
 import {
   trigger,
   state,
@@ -99,9 +99,9 @@ export class PinkToast extends Toast {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected changeDetectorRef: ChangeDetectorRef,
+    protected appRef: ApplicationRef,
   ) {
-    super(toastrService, toastPackage, changeDetectorRef);
+    super(toastrService, toastPackage, appRef);
   }
 
   action(event: Event) {

--- a/src/app/pink.toast.ts
+++ b/src/app/pink.toast.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-access-missing-member */
-import { Component, ApplicationRef } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   trigger,
   state,
@@ -99,9 +99,8 @@ export class PinkToast extends Toast {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected appRef: ApplicationRef,
   ) {
-    super(toastrService, toastPackage, appRef);
+    super(toastrService, toastPackage);
   }
 
   action(event: Event) {

--- a/src/app/pink.toast.ts
+++ b/src/app/pink.toast.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:no-access-missing-member */
-import { Component, ApplicationRef } from '@angular/core';
+import { Component, ChangeDetectorRef } from '@angular/core';
 import {
   trigger,
   state,
@@ -99,9 +99,9 @@ export class PinkToast extends Toast {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected appRef: ApplicationRef,
+    protected changeDetectorRef: ChangeDetectorRef,
   ) {
-    super(toastrService, toastPackage, appRef);
+    super(toastrService, toastPackage, changeDetectorRef);
   }
 
   action(event: Event) {

--- a/src/lib/toastr/toast-component.ts
+++ b/src/lib/toastr/toast-component.ts
@@ -3,7 +3,6 @@ import {
   OnDestroy,
   HostBinding,
   HostListener,
-  ApplicationRef,
 } from '@angular/core';
 import {
   trigger,
@@ -71,7 +70,6 @@ export class Toast implements OnDestroy {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected appRef: ApplicationRef,
   ) {
     this.message = toastPackage.message;
     this.title = toastPackage.title;
@@ -103,9 +101,6 @@ export class Toast implements OnDestroy {
       if (this.options.progressBar) {
         this.intervalId = setInterval(() => this.updateProgress(), 10);
       }
-    }
-    if (this.options.onActivateTick) {
-      this.appRef.tick();
     }
   }
   /**

--- a/src/lib/toastr/toast-component.ts
+++ b/src/lib/toastr/toast-component.ts
@@ -3,7 +3,7 @@ import {
   OnDestroy,
   HostBinding,
   HostListener,
-  ChangeDetectorRef,
+  ApplicationRef,
 } from '@angular/core';
 import {
   trigger,
@@ -71,7 +71,7 @@ export class Toast implements OnDestroy {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected changeDetectorRef: ChangeDetectorRef,
+    protected appRef: ApplicationRef,
   ) {
     this.message = toastPackage.message;
     this.title = toastPackage.title;
@@ -105,7 +105,7 @@ export class Toast implements OnDestroy {
       }
     }
     if (this.options.onActivateTick) {
-      this.changeDetectorRef.detectChanges();
+      this.appRef.tick();
     }
   }
   /**

--- a/src/lib/toastr/toast-component.ts
+++ b/src/lib/toastr/toast-component.ts
@@ -3,7 +3,7 @@ import {
   OnDestroy,
   HostBinding,
   HostListener,
-  ApplicationRef,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {
   trigger,
@@ -71,7 +71,7 @@ export class Toast implements OnDestroy {
   constructor(
     protected toastrService: ToastrService,
     public toastPackage: ToastPackage,
-    protected appRef: ApplicationRef,
+    protected changeDetectorRef: ChangeDetectorRef,
   ) {
     this.message = toastPackage.message;
     this.title = toastPackage.title;
@@ -105,7 +105,7 @@ export class Toast implements OnDestroy {
       }
     }
     if (this.options.onActivateTick) {
-      this.appRef.tick();
+      this.changeDetectorRef.detectChanges();
     }
   }
   /**

--- a/src/lib/toastr/toastr-service.ts
+++ b/src/lib/toastr/toastr-service.ts
@@ -22,6 +22,8 @@ import {
   ToastPackage,
 } from './toastr-config';
 
+import 'rxjs/add/operator/take';
+
 
 export interface ActiveToast {
   toastId?: number;
@@ -198,12 +200,23 @@ export class ToastrService {
     const toastInjector = new ToastInjector(toastPackage, this._injector);
     const component = new ComponentPortal(config.toastComponent, toastInjector);
     ins.portal = overlayRef.attach(component, this.toastrConfig.newestOnTop);
+
     if (!keepInactive) {
+      // Trigger change detection if onActivateTick is set to true
+      if (config.onActivateTick && ins.onShown) {
+        ins.onShown.take(1).subscribe(() => {
+          if (!ins.portal) // Gotta love Typescript's strict null checking
+            return;
+
+          ins.portal.changeDetectorRef.detectChanges();
+        })
+      }
       setTimeout(() => {
         ins.toastRef.activate();
         this.currentlyActive = this.currentlyActive + 1;
       });
     }
+
     this.toasts.push(ins);
     return ins;
   }

--- a/src/lib/toastr/toastr-service.ts
+++ b/src/lib/toastr/toastr-service.ts
@@ -205,11 +205,12 @@ export class ToastrService {
       // Trigger change detection if onActivateTick is set to true
       if (config.onActivateTick && ins.onShown) {
         ins.onShown.take(1).subscribe(() => {
-          if (!ins.portal) // Gotta love Typescript's strict null checking
+          if (!ins.portal) { // Gotta love Typescript's strict null checking
             return;
+        }
 
           ins.portal.changeDetectorRef.detectChanges();
-        })
+        });
       }
       setTimeout(() => {
         ins.toastRef.activate();


### PR DESCRIPTION
closes #226

This would probably have to be a major version bump since it could break everyone extending the toast component. I'm also not sure that this is what we want. @yarrgh