### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ There are **individual options** and **global options**.
 
 ### Individual Options
 
-Passed to `ToastrService.success/error/warn/info/show()`
+Passed to `ToastrService.success/error/warning/info/show()`
 
 | Option            | Type                           | Default           | Description                                                                                                                               |
 | ----------------- | ------------------------------ | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The method in the ToastrService is called 'warn' not 'warning'. This can be confusing for first time users like me ;)