### PR TITLE
fix: Apply proper style to ToastNoAnimation when inactive

### DIFF
--- a/src/lib/toastr/toast-noanimation.component.ts
+++ b/src/lib/toastr/toast-noanimation.component.ts
@@ -43,6 +43,16 @@ export class ToastNoAnimation implements OnDestroy {
   width = -1;
   /** a combination of toast type and options.toastClass */
   @HostBinding('class') toastClasses = '';
+
+  @HostBinding('style')
+  get displayStyle() {
+    if (this.state === 'inactive') {
+      return 'display: none;';
+    }
+
+    return 'display: block';
+  }
+
   /** controls animation */
   state = 'inactive';
   private timeout: any;


### PR DESCRIPTION
ToastNoAnimation component wasn't being hidden when it was inactive. This caused the toasts opened with this component to be displayed when the `maxOpened` limit was reached even though they were 'inactive'.