### PR TITLE
Fix typo in JSDoc of extendedTimeOut

### DIFF
--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -25,10 +25,9 @@ import { ToastRef } from './toast-injector';
   * default: false
   */
   closeButton: boolean;
-  /** time to close after a user hovers over toast */
   /**
-   * show toast progress bar
-   * default: false
+  * time to close after a user hovers over toast
+  * default: 1000
    */
   extendedTimeOut: number;
   /**


### PR DESCRIPTION
Because of a copy-paste mistake the documented default for the number `extendedTimeOut` was the boolean value `false`, which made no sense.