### PR TITLE
inherit bootstrap 4 Close button styles

### DIFF
--- a/src/lib/toastr-bs4-alert.scss
+++ b/src/lib/toastr-bs4-alert.scss
@@ -82,6 +82,8 @@
       text-decoration: underline;
     }
     .toast-close-button {
+      @extend .close;
+      @extend button.close;
       position: relative;
       right: -0.3em;
       top: -0.3em;


### PR DESCRIPTION
Proposed fix for https://github.com/scttcper/ngx-toastr/issues/427
This solution doesn't require addition of ".close" class to the button. Seams to be more reasonable since only needed when ngx-toastr is used together with bootstrap.