### PR TITLE
fix toastr-bs4-alert close button styling

### DIFF
--- a/src/lib/toastr-bs4-alert.scss
+++ b/src/lib/toastr-bs4-alert.scss
@@ -64,12 +64,12 @@
     position: relative;
     overflow: hidden;
     margin: 0 0 6px;
-    padding: .75rem 1.25rem .75rem 50px;
+    padding: 0.75rem 1.25rem 0.75rem 50px;
     width: 300px;
     background-position: 15px center;
     background-repeat: no-repeat;
     background-size: 24px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, .03);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.03);
     pointer-events: auto;
 
     .toast-title {
@@ -90,7 +90,10 @@
       font-weight: bold;
       color: inherit;
       text-shadow: 0 1px 0 #fff;
-      opacity: .5;
+      opacity: 0.5;
+      background: transparent;
+      border: 0;
+      padding: 0;
     }
     .toast-progress {
       position: absolute;
@@ -105,11 +108,11 @@
       color: #000000;
       text-decoration: none;
       cursor: pointer;
-      opacity: .75;
+      opacity: 0.75;
     }
   }
   .toast:hover {
-    box-shadow: 0 0 10px rgba(0, 0, 0, .15);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
     opacity: 1;
     cursor: pointer;
   }
@@ -118,35 +121,61 @@
 @function svg-factory($fill-color, $viewbox, $path) {
   // opacity is 0.9999 otherwise it uses a hex equivelent
   // firefox requires fill rgb
-  @return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="' + $viewbox + '"><path fill="' + rgba($fill-color, 0.999999) + '" d="' + $path + '"/></svg>';
+  @return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="' + $viewbox +
+    '"><path fill="' + rgba($fill-color, 0.999999) + '" d="' + $path +
+    '"/></svg>';
 }
 @function svg-encode($svg) {
   @return 'data:image/svg+xml,' + $svg;
 }
 .toast-success {
   /* https://github.com/FortAwesome/Font-Awesome-Pro/blob/master/advanced-options/raw-svg/solid/check.svg */
-  background-image: url(svg-encode(svg-factory(theme-color-level('success', 6), '0 0 512 512', "M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z")));
+  background-image: url(svg-encode(
+    svg-factory(
+      theme-color-level('success', 6),
+      '0 0 512 512',
+      'M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z'
+    )
+  ));
   color: theme-color-level('success', 6);
   background-color: theme-color-level('success', -10);
   border: 1px solid theme-color-level('success', -9);
 }
 .toast-error {
   /* https://github.com/FortAwesome/Font-Awesome-Pro/blob/master/advanced-options/raw-svg/solid/times-circle.svg */
-  background-image: url(svg-encode(svg-factory(theme-color-level('danger', 6), '0 0 512 512', "M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z")));
+  background-image: url(svg-encode(
+    svg-factory(
+      theme-color-level('danger', 6),
+      '0 0 512 512',
+      'M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z'
+    )
+  ));
   color: theme-color-level('danger', 6);
   background-color: theme-color-level('danger', -10);
   border: 1px solid theme-color-level('danger', -9);
 }
 .toast-info {
   /* https://github.com/FortAwesome/Font-Awesome-Pro/blob/master/advanced-options/raw-svg/solid/info-circle.svg */
-  background-image: url(svg-encode(svg-factory(theme-color-level('info', 6), '0 0 512 512', "M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z")));
+  background-image: url(svg-encode(
+    svg-factory(
+      theme-color-level('info', 6),
+      '0 0 512 512',
+      'M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z'
+    )
+  ));
   color: theme-color-level('info', 6);
   background-color: theme-color-level('info', -10);
   border: 1px solid theme-color-level('info', -9);
 }
 .toast-warning {
   /* https://github.com/FortAwesome/Font-Awesome-Pro/blob/master/advanced-options/raw-svg/solid/exclamation-triangle.svg */
-  background-image: url(svg-encode(svg-factory(theme-color-level('warning', 6), '0 0 576 512', "M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z")));
+  background-image: url(svg-encode(
+    svg-factory(
+      theme-color-level('warning', 6),
+      '0 0 576 512',
+      'M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z'
+    )
+  ));
   color: theme-color-level('warning', 6);
   background-color: theme-color-level('warning', -10);
   border: 1px solid theme-color-level('warning', -9);


### PR DESCRIPTION
There's missing styles for the close button. This doesn't show in the demo because the `button.toast-close-button` class is being applied somehow. That class comes from `toastr.css`

fixes #427 