### PR TITLE
Fixes description for messageClass and titleClass

### DIFF
--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -54,13 +54,13 @@ export interface IndividualConfig {
    */
   positionClass: string;
   /**
-   * css class on to toast title
+   * css class on toast title
    * default: toast-title
    */
   titleClass: string;
   /**
-   * css class on to toast title
-   * default: toast-title
+   * css class on toast message
+   * default: toast-message
    */
   messageClass: string;
   /**


### PR DESCRIPTION
The description for config properties was copied from `titleClass` to `messageClass` resulting in `messageClass` having a misleading description.
The wording in `titleClass` also had a "to" too much.