### PR TITLE
Fix: Function calls are not supported in decorators' when using --prod build closes #542

### DIFF
--- a/src/lib/toastr/toast-noanimation.component.ts
+++ b/src/lib/toastr/toast-noanimation.component.ts
@@ -222,17 +222,19 @@ export const DefaultNoAnimationsGlobalConfig: GlobalConfig = {
 })
 export class ToastNoAnimationModule {
   static forRoot(config: Partial<GlobalConfig> = {}): ModuleWithProviders {
-    const toastrConfig = { ...DefaultNoAnimationsGlobalConfig, ...config };
-    toastrConfig.iconClasses = {
-      ...DefaultNoAnimationsGlobalConfig.iconClasses,
-      ...config.iconClasses,
-    };
     return {
       ngModule: ToastNoAnimationModule,
       providers: [
         {
           provide: TOAST_CONFIG,
-          useValue: toastrConfig,
+          useValue: {
+            ...DefaultNoAnimationsGlobalConfig,
+            ...config,
+            iconClasses: {
+              ...DefaultNoAnimationsGlobalConfig.iconClasses,
+              ...config.iconClasses,
+            }
+          },
         },
       ],
     };

--- a/src/lib/toastr/toastr.module.ts
+++ b/src/lib/toastr/toastr.module.ts
@@ -21,17 +21,19 @@ export const DefaultGlobalConfig: GlobalConfig = {
 })
 export class ToastrModule {
   static forRoot(config: Partial<GlobalConfig> = {}): ModuleWithProviders {
-    const toastrConfig = { ...DefaultGlobalConfig, ...config };
-    toastrConfig.iconClasses = {
-      ...DefaultGlobalConfig.iconClasses,
-      ...config.iconClasses,
-    };
     return {
       ngModule: ToastrModule,
       providers: [
         {
           provide: TOAST_CONFIG,
-          useValue: toastrConfig,
+          useValue: {
+            ...DefaultGlobalConfig,
+            ...config,
+            iconClasses: {
+              ...DefaultGlobalConfig.iconClasses,
+              ...config.iconClasses,
+            }
+          },
         },
       ],
     };
@@ -43,17 +45,19 @@ export class ToastrModule {
 })
 export class ToastrComponentlessModule {
   static forRoot(config: Partial<GlobalConfig> = {}): ModuleWithProviders {
-    const toastrConfig = { ...DefaultNoComponentGlobalConfig, ...config };
-    toastrConfig.iconClasses = {
-      ...DefaultNoComponentGlobalConfig.iconClasses,
-      ...config.iconClasses,
-    };
     return {
       ngModule: ToastrModule,
       providers: [
         {
           provide: TOAST_CONFIG,
-          useValue: toastrConfig,
+          useValue: {
+            ...DefaultGlobalConfig,
+            ...config,
+            iconClasses: {
+              ...DefaultGlobalConfig.iconClasses,
+              ...config.iconClasses,
+            }
+          },
         },
       ],
     };


### PR DESCRIPTION
Fix #542,  'Function calls are not supported in decorators' when using --prod build.

Related to https://github.com/angular/angular/issues/23609