### PR TITLE
fix(core): ensure toast default stays in ngmodule token

### DIFF
--- a/src/lib/toastr/toast-noanimation.component.ts
+++ b/src/lib/toastr/toast-noanimation.component.ts
@@ -228,12 +228,8 @@ export class ToastNoAnimationModule {
         {
           provide: TOAST_CONFIG,
           useValue: {
-            ...DefaultNoAnimationsGlobalConfig,
-            ...config,
-            iconClasses: {
-              ...DefaultNoAnimationsGlobalConfig.iconClasses,
-              ...config.iconClasses,
-            }
+            default: DefaultNoAnimationsGlobalConfig,
+            config,
           },
         },
       ],

--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -220,4 +220,9 @@ export const DefaultNoComponentGlobalConfig: GlobalConfig = {
   progressAnimation: 'decreasing',
 };
 
-export const TOAST_CONFIG = new InjectionToken<GlobalConfig>('ToastConfig');
+export interface ToastToken {
+  default: GlobalConfig;
+  config: Partial<GlobalConfig>;
+}
+
+export const TOAST_CONFIG = new InjectionToken<ToastToken>('ToastConfig');

--- a/src/lib/toastr/toastr.module.ts
+++ b/src/lib/toastr/toastr.module.ts
@@ -27,12 +27,8 @@ export class ToastrModule {
         {
           provide: TOAST_CONFIG,
           useValue: {
-            ...DefaultGlobalConfig,
-            ...config,
-            iconClasses: {
-              ...DefaultGlobalConfig.iconClasses,
-              ...config.iconClasses,
-            }
+            default: DefaultGlobalConfig,
+            config,
           },
         },
       ],
@@ -51,12 +47,8 @@ export class ToastrComponentlessModule {
         {
           provide: TOAST_CONFIG,
           useValue: {
-            ...DefaultGlobalConfig,
-            ...config,
-            iconClasses: {
-              ...DefaultGlobalConfig.iconClasses,
-              ...config.iconClasses,
-            }
+            default: DefaultNoComponentGlobalConfig,
+            config,
           },
         },
       ],

--- a/src/lib/toastr/toastr.service.ts
+++ b/src/lib/toastr/toastr.service.ts
@@ -14,7 +14,7 @@ import { Overlay } from '../overlay/overlay';
 import { ComponentPortal } from '../portal/portal';
 import { ToastInjector, ToastRef } from './toast-injector';
 import { ToastContainerDirective } from './toast.directive';
-import { GlobalConfig, IndividualConfig, ToastPackage, TOAST_CONFIG } from './toastr-config';
+import { GlobalConfig, IndividualConfig, ToastPackage, ToastToken, TOAST_CONFIG } from './toastr-config';
 
 export interface ActiveToast<C> {
   /** Your Toast ID. Use this to close it individually */
@@ -37,6 +37,7 @@ export interface ActiveToast<C> {
 
 @Injectable({ providedIn: 'root' })
 export class ToastrService {
+  toastrConfig: GlobalConfig;
   currentlyActive = 0;
   toasts: ActiveToast<any>[] = [];
   overlayContainer: ToastContainerDirective;
@@ -44,12 +45,22 @@ export class ToastrService {
   private index = 0;
 
   constructor(
-    @Inject(TOAST_CONFIG) public toastrConfig: GlobalConfig,
+    @Inject(TOAST_CONFIG) token: ToastToken,
     private overlay: Overlay,
     private _injector: Injector,
     private sanitizer: DomSanitizer,
     private ngZone: NgZone
   ) {
+    this.toastrConfig = {
+      ...token.default,
+      ...token.config,
+    };
+    if (token.config.iconClasses) {
+      this.toastrConfig.iconClasses = {
+        ...token.default.iconClasses,
+        ...token.config.iconClasses,
+      };
+    }
   }
   /** show toast */
   show(


### PR DESCRIPTION
basically back to what we were doing in v8. because why change.

closes #543