### PR TITLE
Specific instruction on which version to install given the angular version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,16 @@ DEMO: https://scttcper.github.io/ngx-toastr/
 
 ## Install
 
+If you're using Angular 6.x, install the version 9.x of this package:
+
 ```bash
-npm install ngx-toastr --save
+npm install ngx-toastr@9.0.0 --save
+```
+
+If you're using Angular 5.x, install the version 8.x of this package:
+
+```bash
+npm install ngx-toastr@^8.10.2 --save
 ```
 
 `@angular/animations` package is a required dependency for the default toast


### PR DESCRIPTION
using version 9.x.x with Angular 5.x.x cause an error:

A plethora of warnings like this:

> WARNING in ./node_modules/ngx-toastr/fesm5/ngx-toastr.js
1182:143-149 "export 'inject' was not found in '@angular/core'

Ending with this error:

> ERROR in node_modules/ngx-toastr/toastr/toast-injector.d.ts(1,20): error TS2305: Module '"[ommitted]/node_modules/@angular/core/core"' has no exported member 'InjectFlags'.

Simply using version 8.x.x, that was designed for Angular 5.x.x works like a charm 👍 