### PR TITLE
Fix conflict with bootstrap .toast class

### DIFF
--- a/src/lib/toastr.css
+++ b/src/lib/toastr.css
@@ -105,6 +105,7 @@ button.toast-close-button {
   background-size: 24px;
   box-shadow: 0 0 12px #999999;
   color: #FFFFFF;
+  opacity: 1;
 }
 .toast-container .toast:hover {
   box-shadow: 0 0 12px #000000;


### PR DESCRIPTION
Bootstrap 4.3.1 has also a class .toast. It has a property of "opacity: 0;" which makes the toaster invisible unless you hover over it.

Explicitly setting the opacity in this file fixes the issue.