### PR TITLE
docs(toastr-config): toastClass comment

### DIFF
--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -51,7 +51,7 @@ export interface IndividualConfig {
   enableHtml: boolean;
   /**
    * css class on toast component
-   * default: toast
+   * default: ngx-toastr
    */
   toastClass: string;
   /**


### PR DESCRIPTION
Changed toastClass property comment from `default: toast` to `default: ngx-toastr` to match v10.x changes.