### PR TITLE
feat: change default style display behavior to nothing

### DIFF
--- a/src/lib/toastr/toast-noanimation.component.ts
+++ b/src/lib/toastr/toast-noanimation.component.ts
@@ -59,7 +59,6 @@ export class ToastNoAnimation implements OnDestroy {
     if (this.state === 'inactive') {
       return 'none';
     }
-    return 'inherit';
   }
 
   /** controls animation */

--- a/src/lib/toastr/toast.component.ts
+++ b/src/lib/toastr/toast.component.ts
@@ -80,7 +80,6 @@ export class Toast implements OnDestroy {
     if (this.state.value === 'inactive') {
       return 'none';
     }
-    return 'inherit';
   }
 
   private timeout: any;


### PR DESCRIPTION
When toast is create and is non visible this code puts inline style to tag element. Which is bad for 3th part overriding. 

I suggest to not return this  "inherit" and also "display" property to tag. And this will be control with css. 


[Code link](https://github.com/scttcper/ngx-toastr/commit/720af1ac29e5709ed67f890ce722a625dfb321c6#diff-b02c47a7f73543c1c90b62e0df13797bR82)