### PR TITLE
fix: timeOut is not disabled by `disableTimeOut: true` in ToastNoAnimation

### DIFF
--- a/src/lib/toastr/toast-noanimation.component.ts
+++ b/src/lib/toastr/toast-noanimation.component.ts
@@ -109,7 +109,7 @@ export class ToastNoAnimation implements OnDestroy {
    */
   activateToast() {
     this.state = 'active';
-    if ((this.options.disableTimeOut === false || this.options.disableTimeOut !== 'timeOut') && this.options.timeOut) {
+    if (!(this.options.disableTimeOut === true || this.options.disableTimeOut === 'timeOut') && this.options.timeOut) {
       this.timeout = setTimeout(() => {
         this.remove();
       }, this.options.timeOut);


### PR DESCRIPTION
This fix is already applied in the version with animation. In the version without animation the disableTimeOut options doesn't really disable