### PR TITLE
Avoid double message sanitization to allow trusted SafeHtml in toasts

### DIFF
--- a/src/lib/toastr/toastr.service.ts
+++ b/src/lib/toastr/toastr.service.ts
@@ -4,9 +4,7 @@ import {
   Injectable,
   Injector,
   NgZone,
-  SecurityContext
 } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 import { Observable } from 'rxjs';
 
@@ -48,7 +46,6 @@ export class ToastrService {
     @Inject(TOAST_CONFIG) token: ToastToken,
     private overlay: Overlay,
     private _injector: Injector,
-    private sanitizer: DomSanitizer,
     private ngZone: NgZone
   ) {
     this.toastrConfig = {
@@ -266,16 +263,12 @@ export class ToastrService {
       this.overlayContainer
     );
     this.index = this.index + 1;
-    let sanitizedMessage: string | SafeHtml | undefined | null = message;
-    if (message && config.enableHtml) {
-      sanitizedMessage = this.sanitizer.sanitize(SecurityContext.HTML, message);
-    }
 
     const toastRef = new ToastRef(overlayRef);
     const toastPackage = new ToastPackage(
       this.index,
       config,
-      sanitizedMessage,
+      message,
       title,
       toastType,
       toastRef


### PR DESCRIPTION
This pull request adds two test cases to illustrate an issue with HTML sanitization. In the first case, some unsafe HTML (the `onclick` attribute in an anchor tag) is provided in a plain string. The existing behavior is correct; the `<a href="...">` is preserved while the `onclick` is removed. However, when the same HTML is trusted with `DomSanitizer.prototype.bypassSecurityTrustHtml`, the `onclick` is still removed, which is unexpected. 

Angular automatically sanitizes the value in `[innerHTML]="message"`, but ngx-toastr was doing the same to prepare the message for the toast. `DomSanitizer.prototype.sanitize` returns a plain string which in this case still contains `onclick`. However, now as a plain string the message is subject to repeat sanitization by `innerHTML`. No longer a `SafeHtml` due to ngx-toastr's sanitization, the message is sanitized again which removes the `onclick`.

The fix is to simply not sanitize the value before passing it off to innerHTML.

Note that this pull request does not correct any of the loose typing around `string | SafeHtml`. A `SafeHtml` cannot be treated as a string, but I did not notice any code attempting to do that. I did, however, have to work around the test for `message.length` in the test app since that property does not exist on `SafeHtml`.