### PR TITLE
fix: use correct location for import of ModuleWithProviders

### DIFF
--- a/src/lib/toastr/toast-noanimation.component.ts
+++ b/src/lib/toastr/toast-noanimation.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders } from '@angular/compiler/src/core';
+import { ModuleWithProviders } from '@angular/core';
 import {
   ApplicationRef,
   Component,


### PR DESCRIPTION
This issue fixes the warning I'm getting when using this package with Angular 9. 

Related issue: #583 

```
WARNING in Entry point 'ngx-toastr' contains deep imports into '/opt/colmena/kikstart/templates/kikstart-ui-starter/node_modules/@angular/compiler/src/core'. This is probably not a problem, but may cause the compilation of entry points to be out of order.
```