### PR TITLE
Fix Issue #768

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -120,15 +120,27 @@
                 <small id="maxNumberToastsHelp" class="form-text text-muted">0 is no limit</small>
                 <div class="form-check">
                   <input type="checkbox" class="form-check-input" [(ngModel)]="toastr.toastrConfig.autoDismiss" id="autoDismiss">
-                  <label for="disableTimeOut" class="form-check-label" for="autoDismiss">Auto dismiss on max</label>
+                  <label class="form-check-label" for="autoDismiss">Auto dismiss on max</label>
                 </div>
               </div>
               <div class="form-group">
-                <label for="toastExtendedTimeout">
+                <label for="easeTime">
                   <strong>Ease Time</strong>
                 </label>
                 <input type="text" [(ngModel)]="toastr.toastrConfig.easeTime" (ngModelChange)="fixNumber('easeTime')" class="form-control"
-                  id="toastExtendedTimeout">
+                  id="easeTime">
+              </div>
+              <div class="form-group">
+                <label for="toastCustomClass">
+                  <strong>Custom Class</strong>
+                </label>
+                <textarea [(ngModel)]="customClass" rows="1" class="form-control" name="toastClass" id="toastCustomClass" placeholder="class-name"></textarea>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" [(ngModel)]="appendCustomClass" id="appendCustomClass">
+                <label class="form-check-label" for="appendCustomClass">
+                  Append Custom Class
+                </label>
               </div>
             </div>
             <div class="col-md-3">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -49,6 +49,8 @@ export class HomeComponent {
   options: GlobalConfig;
   title = '';
   message = '';
+  customClass = '';
+  appendCustomClass = true;
   type = types[0];
   version = VERSION;
   enableBootstrap = false;
@@ -74,10 +76,22 @@ export class HomeComponent {
       title: t,
     };
   }
+
+  private updateToastClass(options: GlobalConfig) {
+    if (this.customClass && this.customClass.length > 0) {
+      if (this.appendCustomClass) {
+        options.toastClass += ' ' + this.customClass;
+      } else {
+        options.toastClass = this.customClass;
+      }
+    }
+  }
+
   openToast() {
     const { message, title } = this.getMessage();
     // Clone current config so it doesn't change when ngModel updates
     const opt = cloneDeep(this.options);
+    this.updateToastClass(opt);
     const inserted = this.toastr.show(
       message,
       title,
@@ -93,6 +107,7 @@ export class HomeComponent {
     const { message, title } = this.getMessage();
     const opt = cloneDeep(this.options);
     opt.toastComponent = ToastNoAnimation;
+    this.updateToastClass(opt);
     const inserted = this.toastr.show(
       message,
       title,
@@ -108,6 +123,7 @@ export class HomeComponent {
     const opt = cloneDeep(this.options);
     opt.toastComponent = PinkToast;
     opt.toastClass = 'pinktoast';
+    this.updateToastClass(opt);
     const { message, title } = this.getMessage();
     const inserted = this.toastr.show(message, title, opt);
     if (inserted && inserted.toastId) {
@@ -119,6 +135,7 @@ export class HomeComponent {
     const opt = cloneDeep(this.options);
     opt.toastComponent = NotyfToast;
     opt.toastClass = 'notyf confirm';
+    this.updateToastClass(opt);
     // opt.positionClass = 'notyf__wrapper';
     // this.options.newestOnTop = false;
     const { message, title } = this.getMessage();

--- a/src/lib/toastr.css
+++ b/src/lib/toastr.css
@@ -143,6 +143,9 @@ button.toast-close-button {
   background-color: #030303;
   pointer-events: auto;
 }
+.ngx-toastr_pointer-events-enabled {
+  pointer-events: auto;
+}
 .toast-success {
   background-color: #51A351;
 }

--- a/src/lib/toastr/toast.component.ts
+++ b/src/lib/toastr/toast.component.ts
@@ -90,6 +90,9 @@ export class Toast implements OnDestroy {
   private sub1: Subscription;
   private sub2: Subscription;
   private sub3: Subscription;
+  /** specifies the class-name that is used in css. This class also enables pointer-events **/
+  private cssToastClass = 'ngx-toastr';
+  private cssToastPointerEventsClass = 'ngx-toastr_pointer-events-enabled';
 
   constructor(
     protected toastrService: ToastrService,
@@ -103,6 +106,11 @@ export class Toast implements OnDestroy {
     this.toastClasses = `${toastPackage.toastType} ${
       toastPackage.config.toastClass
     }`;
+    if (this.toastClasses.indexOf(this.cssToastClass) < 0) {
+      // user changed class-name. Since pointer-events are disabled in container-element they won't work in toast itself too.
+      // To enable pointer-events we add an additional class without any styles
+      this.toastClasses += ' ' + this.cssToastPointerEventsClass;
+    }
     this.sub = toastPackage.toastRef.afterActivate().subscribe(() => {
       this.activateToast();
     });

--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -52,6 +52,8 @@ export interface IndividualConfig {
   /**
    * css class on toast component
    * default: ngx-toastr
+   * if toastClass is changed an additional class 'ngx-toastr_pointer-events-enabled' will be added to toasts to allow mouse-events in
+   * toasts
    */
   toastClass: string;
   /**


### PR DESCRIPTION
This commit fixes Issue #768 
If there is a custom class defined the default class 'ngx-toastr' will be removed from new toasts. Since pointer-events are disabled in .toast-container and re-enabled in .ngx-toastr removing the latter class will result in disabled pointer-events (including mouse-click to dismiss a toast).

Additionally I added two additional controls in home-component that allows to change toast-class.
