### PR TITLE
feat: Prevent title duplicates with `includeTitleDuplicates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ options:
 | preventDuplicates       | boolean | false                              | Block duplicate messages                                                                                      |
 | countDuplicates         | boolean | false                              | Displays a duplicates counter (preventDuplicates must be true). Toast must have a title and duplicate message |
 | resetTimeoutOnDuplicate | boolean | false                              | Reset toast timeout on duplicate (preventDuplicates must be true)                                             |
+| includeTitleDuplicates  | boolean | false                              | Include the title of a toast when checking for duplicates (by default only message is compared)               |
 
 ##### iconClasses defaults
 
@@ -212,6 +213,8 @@ imports: [
 export interface ActiveToast {
   /** Your Toast ID. Use this to close it individually */
   toastId: number;
+  /** the title of your toast. Stored to prevent duplicates if includeTitleDuplicates set */
+  title: string
   /** the message of your toast. Stored to prevent duplicates */
   message: string;
   /** a reference to the component see portal.ts */

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -101,6 +101,13 @@
                     Reset timeout on duplicate
                   </label>
                 </div>
+                <div class="form-check ml-2">
+                  <input class="form-check-input" type="checkbox" [(ngModel)]="options.includeTitleDuplicates" id="includeTitleDuplicate"
+                    [disabled]="!options.preventDuplicates">
+                  <label class="form-check-label" for="includeTitleDuplicate">
+                    Include title in duplicate checks
+                  </label>
+                </div>
                 <div class="form-check">
                   <input
                     class="form-check-input"

--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -203,7 +203,7 @@ export const DefaultNoComponentGlobalConfig: GlobalConfig = {
   autoDismiss: false,
   newestOnTop: true,
   preventDuplicates: false,
-  countDuplicates: false,  
+  countDuplicates: false,
   resetTimeoutOnDuplicate: false,
   includeTitleDuplicates: false,
 

--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -140,6 +140,11 @@ export interface GlobalConfig extends IndividualConfig {
    * default: false
    */
   resetTimeoutOnDuplicate: boolean;
+  /**
+   * consider the title of a toast when checking if duplicate
+   * default: false
+   */
+  includeTitleDuplicates: boolean;
 }
 
 /**
@@ -198,8 +203,10 @@ export const DefaultNoComponentGlobalConfig: GlobalConfig = {
   autoDismiss: false,
   newestOnTop: true,
   preventDuplicates: false,
-  countDuplicates: false,
+  countDuplicates: false,  
   resetTimeoutOnDuplicate: false,
+  includeTitleDuplicates: false,
+
   iconClasses: {
     error: 'toast-error',
     info: 'toast-info',

--- a/src/lib/toastr/toastr.service.ts
+++ b/src/lib/toastr/toastr.service.ts
@@ -131,12 +131,16 @@ export class ToastrService {
    * Determines if toast message is already shown
    */
   findDuplicate(title = '', message = '', resetOnDuplicate: boolean, countDuplicates: boolean) {
+    const { includeTitleDuplicates } = this.toastrConfig;
+
     for (const toast of this.toasts) {
-      if ((!this.toastrConfig.includeTitleDuplicates || (this.toastrConfig.includeTitleDuplicates && toast.title === title)) && (!message || toast.message === message)) {
+      const hasDuplicateTitle = includeTitleDuplicates && toast.title === title;
+      if ((!includeTitleDuplicates || hasDuplicateTitle) && toast.message === message) {
         toast.toastRef.onDuplicate(resetOnDuplicate, countDuplicates);
         return toast;
       }
     }
+
     return null;
   }
 
@@ -194,7 +198,11 @@ export class ToastrService {
       this.toastrConfig.resetTimeoutOnDuplicate && config.timeOut > 0,
       this.toastrConfig.countDuplicates,
     );
-    if (((this.toastrConfig.includeTitleDuplicates && title) || message) && this.toastrConfig.preventDuplicates && duplicate !== null) {
+    if (
+      ((this.toastrConfig.includeTitleDuplicates && title) || message) &&
+      this.toastrConfig.preventDuplicates &&
+      duplicate !== null
+    ) {
       return duplicate;
     }
 

--- a/src/lib/toastr/toastr.service.ts
+++ b/src/lib/toastr/toastr.service.ts
@@ -130,9 +130,7 @@ export class ToastrService {
   /**
    * Determines if toast message is already shown
    */
-  findDuplicate(title :string, message: string, resetOnDuplicate: boolean, countDuplicates: boolean) {
-    title = (title === undefined) ? '' : title;
-    message = (message === undefined) ? '' : message;
+  findDuplicate(title = '', message = '', resetOnDuplicate: boolean, countDuplicates: boolean) {
     for (const toast of this.toasts) {
       if ((!this.toastrConfig.includeTitleDuplicates || (this.toastrConfig.includeTitleDuplicates && toast.title === title)) && (!message || toast.message === message)) {
         toast.toastRef.onDuplicate(resetOnDuplicate, countDuplicates);


### PR DESCRIPTION
As mentioned in #659 this PR based off #814 contains new global config to include title when checking for duplicates.
Tested locally that without config set, duplicates work as before 

Without includeTitleDuplicates: true
- Multiple duplicates with Title only, allows multiple toasts but stil counts duplicates.
- Multiple duplicates with Message only, wont allow duplicates but doesnt count.
- Two different titles with same message, picks up as duplcate and new title not shown as toast.

With includeTitleDuplicates: true
- Multiple duplicates with Title only, wont display duplicates and counts correctly
- Multiple duplicates with Message only, wont allow duplicates but still doesnt count.
- Two different titles with same message, no longer sees this as duplicate and new toast shown.

closes #659 
closes #814 
