### PR TITLE
fix: Add payload property to the IndividualConfig Interface

### DIFF
--- a/src/lib/toastr/toastr-config.ts
+++ b/src/lib/toastr/toastr-config.ts
@@ -236,6 +236,8 @@ export const DefaultNoComponentGlobalConfig: GlobalConfig = {
   tapToDismiss: true,
   onActivateTick: false,
   progressAnimation: 'decreasing',
+
+  payload: null
 };
 
 export interface ToastToken {


### PR DESCRIPTION
This added property on IndividualConfig allows us to pass some extra data to our custom toastComponent (like a theme, or an extra cta label or anything)

At first I wanted to dig something like it is described here:
https://github.com/scttcper/ngx-toastr/issues/878

But I found the payload workaround much more easier to code and use.