### PR TITLE
fix: extendedTimeOut and mouseenter event issue

### DIFF
--- a/src/lib/toastr/toast.component.ts
+++ b/src/lib/toastr/toast.component.ts
@@ -201,13 +201,16 @@ export class Toast implements OnDestroy {
     if (this.state.value === 'removed') {
       return;
     }
-    clearTimeout(this.timeout);
-    this.options.timeOut = 0;
-    this.hideTime = 0;
 
-    // disable progressBar
-    clearInterval(this.intervalId);
-    this.width = 0;
+    if (this.options.disableTimeOut !== 'extendedTimeOut') {
+      clearTimeout(this.timeout);
+      this.options.timeOut = 0;
+      this.hideTime = 0;
+  
+      // disable progressBar
+      clearInterval(this.intervalId);
+      this.width = 0;
+    }
   }
   @HostListener('mouseleave')
   delayedHideToast() {


### PR DESCRIPTION
I'm not sure if this was intentional, if it was you can ignore/close this PR request

commit message: fix issue with mouseenter event clearing the timeout when disableTimeOut was set to extendedTimeOut

[Current behaviour](https://gyazo.com/7c1e544cb8b73b52f5db8d2a68b0d455) VS [New behaviour](https://gyazo.com/28d5e6fe4e2a276cb7d5ec17940985a4)