### PR TITLE
docs: update `onTap` doc to to use toast reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,14 +394,12 @@ ngOnInit() {
 
 ```ts
 showToaster() {
-  this.toastr.success('Hello world!', 'Toastr fun!')
-    .onTap
-    .pipe(take(1))
-    .subscribe(() => this.toasterClickedHandler());
+  const toast = this.toastr.success('Hello world!', 'Toastr fun!');
+  toast.onTap.pipe(take(1)).subscribe(() => this.toasterClickedHandler(toast));
 }
 
-toasterClickedHandler() {
-  console.log('Toastr clicked');
+toasterClickedHandler(toast: ActiveToast<any>) {
+  console.log(`Toastr ${toast.toastId} clicked`);
 }
 ```
 


### PR DESCRIPTION
Related to https://github.com/scttcper/ngx-toastr/issues/470 and https://github.com/scttcper/ngx-toastr/pull/598, this PR updates the documentation for how the reference of a specific toast can be used in conjunction with the event callback.

When I first implemented this library, it wasn't quite intuitive how this could be accomplished (as there the callback event is `void` instead of one with a payload).

I think the same problem (unclear how to accomplish) generated issues https://github.com/scttcper/ngx-toastr/issues/647 and https://github.com/scttcper/ngx-toastr/issues/408. So hopefully this PR makes it clear how it can be accomplished.