### PR TITLE
docs: fix demo to show progress for pink toast

### DIFF
--- a/src/app/pink.toast.ts
+++ b/src/app/pink.toast.ts
@@ -54,7 +54,7 @@ import { Toast, ToastrService, ToastPackage } from '../lib/public_api';
     </div>
   </div>
   <div *ngIf="options.progressBar">
-    <div class="toast-progress" [style.width]="width + '%'"></div>
+    <div class="toast-progress" [style.width]="width() + '%'"></div>
   </div>
   `,
   animations: [


### PR DESCRIPTION
I was making a custom toast component based off of the pink demo component, but the progress indicator was not showing.  The demo is missing the function call parenthesis!


![image](https://github.com/user-attachments/assets/5321f5b8-8eae-4f19-ab89-13ea7db2d59c)
